### PR TITLE
Add outline attribute introduced with v10.0.14

### DIFF
--- a/config/DFIR-ORC_config.xml
+++ b/config/DFIR-ORC_config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <wolf childdebug="no" command_timeout="600">
     <log disposition="truncate">DFIR-ORC_{SystemType}_{FullComputerName}_{TimeStamp}.log</log>
+    <outline disposition="truncate">DFIR-ORC_{SystemType}_{FullComputerName}.json</outline>
 
     <archive name="DFIR-ORC_{SystemType}_{FullComputerName}_Main.7z" keyword="Main" concurrency="2" repeat="Once" compression="fast">
         <restrictions JobMemoryLimit="3G" ProcessMemoryLimit="2G" ElapsedTimeLimit="360"/>


### PR DESCRIPTION
Hello,

I propose you to add the `outline` attribute introduced with DFIR-ORC v10.0.14 to the example configuration file.

Regards, 