### PR TITLE
Patch GetEVT modules over all drives

### DIFF
--- a/config/GetEVT_config.xml
+++ b/config/GetEVT_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <getthis reportall="">
-  <location>%SystemDrive%\</location>
+  <location>*</location>
   <samples MaxPerSampleBytes="3GB" MaxTotalBytes="25GB" MaxSampleCount="200000">
     <sample name="evtx">
       <ntfs_find name_match="*.evtx" header="ElfFile" />

--- a/config/GetEVT_little_config.xml
+++ b/config/GetEVT_little_config.xml
@@ -13,12 +13,12 @@
             <ntfs_exclude name_match="microsoft-windows-hcs-*.evtx" />
             <ntfs_exclude name="microsoft office web apps.evtx" />
             <ntfs_exclude name_match="microsoft-team foundation server-*.evtx" />
-            <!-- Target the collection of event logs in the "default" path only. -->
-            <ntfs_find path_match="\Windows\System32\WinEVT\logs\*.evtx" />
+            <!-- Target the collection of event logs with header check. -->
+            <ntfs_find path_match="*.evtx" header="ElfFile"/>
         </sample>
         <sample name="evt">
-            <!-- Target the collection of event logs in the "default" path only. -->
-            <ntfs_find path_match="\Windows\System32\Config\*.evt" header_hex="300000004c664c65" />
+            <!-- Target the collection of event logs with header check. -->
+            <ntfs_find path_match="*.evt" header_hex="300000004c664c65" />
         </sample>
     </samples>
 </getthis>

--- a/config/GetEVT_little_config.xml
+++ b/config/GetEVT_little_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <getthis reportall="" hash="none">
     <!-- <output compression="ultra" /> -->
-    <location>%SystemDrive%\</location>
+    <location>*</location>
     <samples MaxPerSampleBytes="3GB" MaxTotalBytes="25GB" MaxSampleCount="200000">
         <sample name="evtx">
             <!-- Exclude some notoriously big event logs -->


### PR DESCRIPTION
With actual config files :
- *GetEVT_config.xml*
- *GetEVT_little_config.xml*

We don't retrieve the Windows eventlogs from all drives.

Lets assume that on servers we stored the Windows eventlogs on a separate drive.
With current xml file **we missed all Windows eventlogs files gathering**.

A fix would be to include all drives :

```xml
  <location>*</location>                <!-- Replaced %SystemDrive%\ by * -->
```
And remove hardcoded paths from *GetEVT_little_config.xml*, with a fix to header that was missing for *.evtx*

```xml
  <location>*</location>                <!-- Replaced %SystemDrive%\ by * -->
...
            <ntfs_find path_match="*.evtx" header="ElfFile"/>
...
            <ntfs_find path_match="*.evt" header_hex="300000004c664c65" />
...
```